### PR TITLE
Cordova9対応

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 ## Change Log - 更新履歴
 
-ver. 1.3.0: Enable background buffering.
+- ver. 1.3.1: Cordova9 complient.
+- ver. 1.3.0: Enable background buffering.
 
 ## How to use - 使い方
 
@@ -13,8 +14,6 @@ ver. 1.3.0: Enable background buffering.
 ```
 ├── README.md                              # This document - 本文書
 ├── hooks
-│   ├── android_after_plugin_install.js    # インストール時フックスクリプト(Android)
-│   ├── android_before_plugin_uninstall.js # アンインストール時フックスクリプト(Android)
 │   └── ios_after_plugin_install.js        # インストール時フックスクリプト(iOS)
 ├── node_modules                           # 依存するnodejsモジュール群(iOS)
 │   └── ...
@@ -45,7 +44,7 @@ ver. 1.3.0: Enable background buffering.
 ```
 {
     code: -100,
-    message: "some message" 
+    message: "some message"
 }
 ```
 
@@ -113,7 +112,6 @@ CALIB_BOTH_FINISHED: 3
 }
 ```
 
-
 ## Android
 
 ### SDK
@@ -123,24 +121,6 @@ CALIB_BOTH_FINISHED: 3
 ### App setting - アプリ設定
 
 * 設定 => Apps => 「該当アプリ」でBluetoothをONにすること
-
-### Dependent libraries - 依存するライブラリ等
-
-* AndroidプラグインではAndroidManifest.xmlのtargetSdkVersionを変更するために以下のスクリプトを使用している
-
-#### android_after_plugin_install.js
-
-* cordovaのフックスクリプト
-* AndroidManifest.xmlのandroid:targetSdkVersionを22に変更
-	* BluetoothのPermission問題を解決するため
-	* 23以上だとエラーが発生
-		* ACCESS_COARSE_LOCATIONとACCESS_FINE_LOCATIONを記述していても、エラーとなってしまう
-		* gradleのバージョンを上げれば23以上でも対応可能だが、Cordovaコマンドからの更新は難しい
-	* 元々のtargetSdkVersionをhooks/original_versionファイルに保存
-
-#### android_before_plugin_uninstall.js
-
-* JINS MEMEプラグインを取り除く際に、ANdroidManifest.xmlのandroid:targetSdkVersionを元に戻す
 
 ## iOS
 

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ CALIB_BOTH_FINISHED: 3
 
 ### App setting - アプリ設定
 
-* 設定 => Apps => 「該当アプリ」でBluetoothをONにすること
+* [cordova-diagnostic-plugin](https://github.com/dpa99c/cordova-diagnostic-plugin) などのユーザー許可ダイアログを使用し、permission.ACCESS_COARSE_LOCATION の権限を取得してからスキャンを開始してください。
 
 ## iOS
 

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ CALIB_BOTH_FINISHED: 3
 
 * JINS MEME SDK iOS 1.2.0
 
-### Dependent noode.js module - 依存するnodejsモジュール
+### Dependent node.js module - 依存するnodejsモジュール
 
 iOSプラグインではXcodeのEmbedded BinariesにMEMELib.frameworkを追加するためにnode-xcodeを使用している。node-xcodeとその依存ライブラリは基本的にMIT LicenseとUnlicenseで使用可能である。各種詳細と依存関係は以下の通り。
 

--- a/hooks/android_after_plugin_install.js
+++ b/hooks/android_after_plugin_install.js
@@ -4,7 +4,7 @@ var manifestPath = path.resolve(__dirname + '/../../../platforms/android/Android
 var saveFilePath = path.resolve(__dirname + '/original_version');
 
 module.exports = function(context) {
-    var Q = context.requireCordovaModule("q");
+    var Q = require('q');
     var deferral = new Q.defer();
 
     console.log('Read: ' + manifestPath);
@@ -14,7 +14,7 @@ module.exports = function(context) {
             deferral.reject("JINS MEME SDK - android_after_plugin_install: " + JSON.stringify(err));
             return;
         }
- 
+
         if (!text) {
             console.log('No content: ' + manifestPath);
             deferral.reject("JINS MEME SDK - android_after_plugin_install: no manifest file");

--- a/hooks/android_before_plugin_uninstall.js
+++ b/hooks/android_before_plugin_uninstall.js
@@ -5,7 +5,7 @@ var saveFilePath = path.resolve(__dirname + '/original_version');
 var sdkVersion = 23;
 
 module.exports = function(context) {
-    var Q = context.requireCordovaModule("q");
+    var Q = require('q');
     var deferral = new Q.defer();
 
     console.log('Read: ' + saveFilePath);
@@ -28,10 +28,10 @@ module.exports = function(context) {
                 deferral.resolve();
                 return;
             }
-     
+
             var regex = /android:targetSdkVersion="([0-9]+)"/;
             var replaced = text.replace(regex, 'android:targetSdkVersion="' + sdkVersion + '"');
-        
+
             fs.writeFile(manifestPath, replaced, function (err) {
                 if (err) {
                     console.log('Failed to rewrite: ' + manifestPath);

--- a/hooks/ios_after_plugin_install.js
+++ b/hooks/ios_after_plugin_install.js
@@ -13,7 +13,7 @@ module.exports = function(context) {
 
       // Need a promise so that the install waits for us to complete our project modifications
       // before the plugin gets installed.
-      var Q = context.requireCordovaModule("q");
+      var Q = require('q');
       var deferral = new Q.defer();
 
       var platforms = context.opts.cordova.platforms;
@@ -30,8 +30,8 @@ module.exports = function(context) {
       // been upgraded to support embedded binaries.
 
       // Cordova libs to get the project path and project name so we can locate the xcode project file.
-      var cordova_util = context.requireCordovaModule("cordova-lib/src/cordova/util"),
-          ConfigParser = context.requireCordovaModule("cordova-lib").configparser,
+      var cordova_util = require('cordova-lib/src/cordova/util'),
+          ConfigParser = require('cordova-lib').configparser,
           projectRoot = cordova_util.isCordova(),
           xml = cordova_util.projectConfig(projectRoot),
           cfg = new ConfigParser(xml);

--- a/hooks/ios_after_plugin_install.js
+++ b/hooks/ios_after_plugin_install.js
@@ -30,8 +30,8 @@ module.exports = function(context) {
       // been upgraded to support embedded binaries.
 
       // Cordova libs to get the project path and project name so we can locate the xcode project file.
-      var cordova_util = require('cordova-lib/src/cordova/util'),
-          ConfigParser = require('cordova-lib').configparser,
+      var cordova_util = context.requireCordovaModule("cordova-lib/src/cordova/util"),
+          ConfigParser = context.requireCordovaModule("cordova-common").ConfigParser;
           projectRoot = cordova_util.isCordova(),
           xml = cordova_util.projectConfig(projectRoot),
           cfg = new ConfigParser(xml);

--- a/plugin.xml
+++ b/plugin.xml
@@ -48,6 +48,7 @@
         <header-file src="src/ios/JinsMemeRtDataBuffer.h" />
         <source-file src="src/ios/JinsMemeRtDataBuffer.m" />
         <framework src="src/ios/MEMELib.framework" custom="true" embed="true" />
+        <hook type="after_plugin_install" src="hooks/ios_after_plugin_install.js" />
         <framework src="CoreBluetooth.framework" />
     </platform>
 </plugin>

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<plugin id="com.jinsjp.meme.plugin" version="1.3.0" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
+<plugin id="com.jins_jp.meme.plugin" version="1.3.0" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
     <name>JINS MEME Plugin</name>
     <description>JINS MEME SDK Plugin</description>
     <license></license>
@@ -13,7 +13,7 @@
     <platform name="android">
         <config-file parent="/*" target="res/xml/config.xml">
             <feature name="JinsMemePlugin">
-                <param name="android-package" value="com.jinsjp.meme.plugin.JinsMemePlugin" />
+                <param name="android-package" value="com.jins_jp.meme.plugin.JinsMemePlugin" />
             </feature>
         </config-file>
         <config-file parent="/*" target="AndroidManifest.xml">
@@ -24,13 +24,11 @@
             <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
             <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
         </config-file>
-        <source-file src="src/android/JinsMemePlugin.java" target-dir="src/com/jinsjp/meme/plugin" />
-        <source-file src="src/android/Message.java" target-dir="src/com/jinsjp/meme/plugin" />
-        <source-file src="src/android/RtDataBuffer.java" target-dir="src/com/jinsjp/meme/plugin" />
+        <source-file src="src/android/JinsMemePlugin.java" target-dir="src/com/jins_jp/meme/plugin" />
+        <source-file src="src/android/Message.java" target-dir="src/com/jins_jp/meme/plugin" />
+        <source-file src="src/android/RtDataBuffer.java" target-dir="src/com/jins_jp/meme/plugin" />
         <lib-file src="src/android/MemeLib.jar" />
         <framework src="com.google.code.gson:gson:2.3" />
-        <hook type="after_plugin_install" src="hooks/android_after_plugin_install.js" />
-        <hook type="before_plugin_uninstall" src="hooks/android_before_plugin_uninstall.js" />
     </platform>
     <platform name="ios">
         <config-file parent="/*" target="config.xml">
@@ -51,6 +49,5 @@
         <source-file src="src/ios/JinsMemeRtDataBuffer.m" />
         <framework src="src/ios/MEMELib.framework" custom="true" embed="true" />
         <framework src="CoreBluetooth.framework" />
-        <hook type="after_plugin_install" src="hooks/ios_after_plugin_install.js" />
     </platform>
 </plugin>

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,11 +1,11 @@
 <?xml version='1.0' encoding='utf-8'?>
-<plugin id="com.jins_jp.meme.plugin" version="1.3.0" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
+<plugin id="com.jins_jp.meme.plugin" version="1.3.1" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
     <name>JINS MEME Plugin</name>
     <description>JINS MEME SDK Plugin</description>
     <license></license>
     <keywords>monaca,cordova,JINS MEME</keywords>
     <engines>
-        <engine name="cordova" version=">=6.2.0" />
+        <engine name="cordova" version=">=9.0.0" />
     </engines>
     <js-module name="JinsMemePlugin" src="www/jins_meme_plugin.js">
         <clobbers target="cordova.plugins.JinsMemePlugin" />

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<plugin id="com.jins_jp.meme.plugin" version="1.3.0" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
+<plugin id="com.jinsjp.meme.plugin" version="1.3.0" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
     <name>JINS MEME Plugin</name>
     <description>JINS MEME SDK Plugin</description>
     <license></license>
@@ -13,7 +13,7 @@
     <platform name="android">
         <config-file parent="/*" target="res/xml/config.xml">
             <feature name="JinsMemePlugin">
-                <param name="android-package" value="com.jins_jp.meme.plugin.JinsMemePlugin" />
+                <param name="android-package" value="com.jinsjp.meme.plugin.JinsMemePlugin" />
             </feature>
         </config-file>
         <config-file parent="/*" target="AndroidManifest.xml">
@@ -24,9 +24,9 @@
             <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
             <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
         </config-file>
-        <source-file src="src/android/JinsMemePlugin.java" target-dir="src/com/jins_jp/meme/plugin" />
-        <source-file src="src/android/Message.java" target-dir="src/com/jins_jp/meme/plugin" />
-        <source-file src="src/android/RtDataBuffer.java" target-dir="src/com/jins_jp/meme/plugin" />
+        <source-file src="src/android/JinsMemePlugin.java" target-dir="src/com/jinsjp/meme/plugin" />
+        <source-file src="src/android/Message.java" target-dir="src/com/jinsjp/meme/plugin" />
+        <source-file src="src/android/RtDataBuffer.java" target-dir="src/com/jinsjp/meme/plugin" />
         <lib-file src="src/android/MemeLib.jar" />
         <framework src="com.google.code.gson:gson:2.3" />
         <hook type="after_plugin_install" src="hooks/android_after_plugin_install.js" />


### PR DESCRIPTION
- 以前のバージョンでは無理やりtargerSdkVersionを落として権限をスルーしていたが、古いtargerSdkVersionではストア掲載できなくなったので、この処理をしているAndroidのhookスクリプトをすべて削除
- AndroidのACCESS_COARSE_LOCATIONの権限付与は cordova-diagnostic-plugin の使用を推奨することにする